### PR TITLE
adds get cluster resource allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/Vanilla/CloudInterops/InfrastructureInterface.php
+++ b/Vanilla/CloudInterops/InfrastructureInterface.php
@@ -59,4 +59,11 @@ interface InfrastructureInterface {
      * @return bool
      */
     public function isFeatureEnable(string $featureName, bool $default = true): bool;
+
+    /**
+     * Returns information related to the Cluster's resources allocation
+     *
+     * @return array Empty array for non-infrastructure environments
+     */
+    public function getClusterResourceAllocation(): array;
 }


### PR DESCRIPTION
`public function getClusterResourceAllocation(): array`
Returns information related to the Cluster's resources allocation.
Empty array for non-infrastructure environments