### PR TITLE
VNLA-2217 Relicense to Proprietary.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "vanilla/cloud-interops",
   "description": "Provides Vanilla Cloud contracts",
   "type": "library",
-  "license": "GPL-2.0",
+  "license": "proprietary",
   "require": {
     "php": ">=7.2.0"
   },


### PR DESCRIPTION
We are moving away from GPL and it looks like this repo was wrongfully set to GPL-2.0.

See: https://higherlogic.atlassian.net/browse/VNLA-2217